### PR TITLE
Issue #2 - Component highlighter

### DIFF
--- a/Search-Swing/pom.xml
+++ b/Search-Swing/pom.xml
@@ -24,6 +24,13 @@
   		<scope>test</scope>
   	</dependency>
   	<dependency>
+	    <groupId>org.mockito</groupId>
+	    <artifactId>mockito-core</artifactId>
+	    <version>4.0.0</version>
+	    <scope>test</scope>
+	</dependency>
+  	
+  	<dependency>
   		<groupId>com.github.alanschaeffer</groupId>
   		<artifactId>search-core</artifactId>
   		<version>0.0.1-SNAPSHOT</version>

--- a/Search-Swing/src/main/java/com/github/alanschaeffer/search/swing/components/highlighter/ComponentHighlighter.java
+++ b/Search-Swing/src/main/java/com/github/alanschaeffer/search/swing/components/highlighter/ComponentHighlighter.java
@@ -31,7 +31,7 @@ public class ComponentHighlighter {
 	}
 	
 	public synchronized void unhighlight(JComponent component) {
-		if(currentlyHighlightedComponent != null) {
+		if(currentlyHighlightedComponent != null && currentlyHighlightedComponent == component) {
 			highlight(null);
 		}
 	}

--- a/Search-Swing/src/main/java/com/github/alanschaeffer/search/swing/components/highlighter/ComponentHighlighter.java
+++ b/Search-Swing/src/main/java/com/github/alanschaeffer/search/swing/components/highlighter/ComponentHighlighter.java
@@ -5,12 +5,34 @@ import javax.swing.JComponent;
 public class ComponentHighlighter {
 
 	private final Effect effect;
+	private UnhighlightTrigger unhighlightTrigger = UnhighlightTrigger.NEVER_UNHILIGHT;
+	
+	private JComponent currentlyHighlightedComponent;
 
 	public ComponentHighlighter(Effect effect) {
 		this.effect = effect;
 	}
+	
+	public void setUnhighlightTrigger(UnhighlightTrigger unhighlightTrigger) {
+		if(unhighlightTrigger == null) this.unhighlightTrigger = UnhighlightTrigger.NEVER_UNHILIGHT;
+		else this.unhighlightTrigger = unhighlightTrigger;
+	}
 
-	public void highlight(JComponent component) {
-		effect.activate(component);
+	public synchronized void highlight(JComponent component) {
+		if(currentlyHighlightedComponent != null) {
+			effect.deactivate(currentlyHighlightedComponent);
+		}
+		currentlyHighlightedComponent = component;
+		
+		if(component != null) {
+			effect.activate(component);
+			unhighlightTrigger.activate(() -> unhighlight(component));
+		}
+	}
+	
+	public synchronized void unhighlight(JComponent component) {
+		if(currentlyHighlightedComponent != null) {
+			highlight(null);
+		}
 	}
 }

--- a/Search-Swing/src/main/java/com/github/alanschaeffer/search/swing/components/highlighter/ComponentHighlighter.java
+++ b/Search-Swing/src/main/java/com/github/alanschaeffer/search/swing/components/highlighter/ComponentHighlighter.java
@@ -1,0 +1,16 @@
+package com.github.alanschaeffer.search.swing.components.highlighter;
+
+import javax.swing.JComponent;
+
+public class ComponentHighlighter {
+
+	private final Effect effect;
+
+	public ComponentHighlighter(Effect effect) {
+		this.effect = effect;
+	}
+
+	public void highlight(JComponent component) {
+		effect.activate(component);
+	}
+}

--- a/Search-Swing/src/main/java/com/github/alanschaeffer/search/swing/components/highlighter/Effect.java
+++ b/Search-Swing/src/main/java/com/github/alanschaeffer/search/swing/components/highlighter/Effect.java
@@ -1,0 +1,11 @@
+package com.github.alanschaeffer.search.swing.components.highlighter;
+
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+
+public interface Effect {
+
+	void activate(JComponent component);
+
+	void deactivate(JComponent component);
+}

--- a/Search-Swing/src/main/java/com/github/alanschaeffer/search/swing/components/highlighter/Effect.java
+++ b/Search-Swing/src/main/java/com/github/alanschaeffer/search/swing/components/highlighter/Effect.java
@@ -1,7 +1,6 @@
 package com.github.alanschaeffer.search.swing.components.highlighter;
 
 import javax.swing.JComponent;
-import javax.swing.JLabel;
 
 public interface Effect {
 

--- a/Search-Swing/src/main/java/com/github/alanschaeffer/search/swing/components/highlighter/UnhighlightTrigger.java
+++ b/Search-Swing/src/main/java/com/github/alanschaeffer/search/swing/components/highlighter/UnhighlightTrigger.java
@@ -1,0 +1,8 @@
+package com.github.alanschaeffer.search.swing.components.highlighter;
+
+public interface UnhighlightTrigger {
+
+	void activate(Runnable unhighlight);
+	
+	public static final UnhighlightTrigger NEVER_UNHILIGHT = r -> {};
+}

--- a/Search-Swing/src/test/java/com/github/alanschaeffer/search/swing/components/highlighter/ComponentHighlighterTest.java
+++ b/Search-Swing/src/test/java/com/github/alanschaeffer/search/swing/components/highlighter/ComponentHighlighterTest.java
@@ -60,6 +60,21 @@ public class ComponentHighlighterTest {
 		assertEquals("original", component.getText());
 	}
 	
+	@Test
+	public void test_Dont_Unhighlight_Unrelated_Component() {
+		var component = new JLabel("original");
+		var unrelatedComponent = new JLabel("other");
+		
+		var effect = new TestEffect(c -> ((JLabel) c).setText("activated"), c -> ((JLabel) c).setText("original"));
+		var highlighter = new ComponentHighlighter(effect);
+		highlighter.setUnhighlightTrigger(r -> highlighter.unhighlight(unrelatedComponent));
+		
+		highlighter.highlight(component);
+		
+		assertEquals("activated", component.getText());
+		assertEquals("other", unrelatedComponent.getText());
+	}
+	
 	private static class TestEffect implements Effect {
 		
 		private Consumer<JComponent> activateEffect;

--- a/Search-Swing/src/test/java/com/github/alanschaeffer/search/swing/components/highlighter/ComponentHighlighterTest.java
+++ b/Search-Swing/src/test/java/com/github/alanschaeffer/search/swing/components/highlighter/ComponentHighlighterTest.java
@@ -23,6 +23,43 @@ public class ComponentHighlighterTest {
 		assertEquals("activated", component.getText());
 	}
 	
+	@Test
+	public void test_Only_One_Highlighted_Component_At_A_Time() {
+		var label1 = new JLabel("original");
+		var label2 = new JLabel("original");
+		
+		var effect = new TestEffect(c -> ((JLabel) c).setText("activated"), c -> ((JLabel) c).setText("original"));
+		var highlighter = new ComponentHighlighter(effect);
+		
+		highlighter.highlight(label1);
+		
+		assertEquals("activated", label1.getText());
+		assertEquals("original", label2.getText());
+		
+		highlighter.highlight(label2);
+		
+		assertEquals("original", label1.getText());
+		assertEquals("activated", label2.getText());
+	}
+	
+	@Test
+	public void test_Unhighlight_Trigger() {
+		var component = new JLabel("original");
+		
+		var effect = new TestEffect(c -> ((JLabel) c).setText("activated"), c -> ((JLabel) c).setText("original"));
+		var unhighlightTrigger = new TestUnhighlightTrigger();
+		var highlighter = new ComponentHighlighter(effect);
+		highlighter.setUnhighlightTrigger(unhighlightTrigger);
+		
+		highlighter.highlight(component);
+		
+		assertEquals("activated", component.getText());
+		
+		unhighlightTrigger.trigger();
+		
+		assertEquals("original", component.getText());
+	}
+	
 	private static class TestEffect implements Effect {
 		
 		private Consumer<JComponent> activateEffect;
@@ -41,6 +78,20 @@ public class ComponentHighlighterTest {
 		@Override
 		public void deactivate(JComponent component) {
 			deactivateEffect.accept(component);
+		}
+	}
+	
+	private static class TestUnhighlightTrigger implements UnhighlightTrigger {
+
+		private Runnable current;
+		
+		@Override
+		public void activate(Runnable unhighlight) {
+			current = unhighlight;
+		}
+		
+		public void trigger() {
+			if(current != null) current.run();
 		}
 	}
 }

--- a/Search-Swing/src/test/java/com/github/alanschaeffer/search/swing/components/highlighter/ComponentHighlighterTest.java
+++ b/Search-Swing/src/test/java/com/github/alanschaeffer/search/swing/components/highlighter/ComponentHighlighterTest.java
@@ -1,0 +1,46 @@
+package com.github.alanschaeffer.search.swing.components.highlighter;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.function.Consumer;
+
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+
+import org.junit.Test;
+
+public class ComponentHighlighterTest {
+
+	@Test
+	public void test_Highlight() {
+		var component = new JLabel("label");
+	
+		var effect = new TestEffect(c -> ((JLabel) c).setText("activated"), c -> {});
+		var highlighter = new ComponentHighlighter(effect);
+		
+		highlighter.highlight(component);
+		
+		assertEquals("activated", component.getText());
+	}
+	
+	private static class TestEffect implements Effect {
+		
+		private Consumer<JComponent> activateEffect;
+		private Consumer<JComponent> deactivateEffect;
+
+		public TestEffect(Consumer<JComponent> activateEffect, Consumer<JComponent> deactivateEffect) {
+			this.activateEffect = activateEffect;
+			this.deactivateEffect = deactivateEffect;
+		}
+
+		@Override
+		public void activate(JComponent component) {
+			activateEffect.accept(component);
+		}
+
+		@Override
+		public void deactivate(JComponent component) {
+			deactivateEffect.accept(component);
+		}
+	}
+}


### PR DESCRIPTION
Created component highlighter, supposed to temporarily visually highlight a component that has been found by the standard search component, so the user can quickly visually find the component in the form.

closes #2 